### PR TITLE
Add `keyword` key to plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,5 +52,6 @@ const plugin = ({ term, actions, display }) => {
 }
 
 module.exports = {
-  fn: plugin
+  fn: plugin,
+  keyword: 'brew'
 }


### PR DESCRIPTION
After this change Cerebro will show autocomplete when you enter `br` -> `brew`